### PR TITLE
add SILENT_ENSURE macro

### DIFF
--- a/tests/verbose_tests.py
+++ b/tests/verbose_tests.py
@@ -28,6 +28,19 @@ class THCVerboseTestCase(THCTestCase):
 
 Run 1 test with 0 failures and 0 segfaults in SECONDS""")
 
+    def test_simple_successful_silent_ensure(self):
+        self.assertNoDiff("""\
+            #include "thc.h"
+            void one_should_equal_to_one() {
+                SILENT_ENSURE(1 == 1);
+            }
+            int main() {
+                thc_addtest(one_should_equal_to_one);
+                return thc_run(THC_VERBOSE);
+            }
+            """,
+            """Run 1 test with 0 failures and 0 segfaults in SECONDS""")
+
     def test_simple_unsuccessful_ensure(self):
         self.assertNoDiff("""\
             #include "thc.h"

--- a/thc.c
+++ b/thc.c
@@ -24,8 +24,8 @@ PRIVATE long nfailures = 0;
 PRIVATE long nsegfaults = 0;
 PRIVATE void (*tests[THC_MAX_TESTS])(void);
 
-PRIVATE void thc_add_success(const char *expr, const char *func, const char *filename, const int fileno);
-PRIVATE void thc_add_failure(const char *expr, const char *func, const char *filename, const int fileno);
+PRIVATE void thc_add_success(const char *expr, const char *func, const char *filename, const int fileno, const int silent);
+PRIVATE void thc_add_failure(const char *expr, const char *func, const char *filename, const int fileno, const int silent);
 PRIVATE void thc_report_tests(void);
 
 PRIVATE void thc_calc_time(struct timeval start, struct timeval stop, double *time_elapsed){
@@ -33,18 +33,18 @@ PRIVATE void thc_calc_time(struct timeval start, struct timeval stop, double *ti
 }
 
 
-PRIVATE void thc_add_success(const char *expr, const char *func, const char *filename, const int fileno) {
-    if (verbose_tests) {
+PRIVATE void thc_add_success(const char *expr, const char *func, const char *filename, const int fileno, const int silent) {
+    if (verbose_tests && !silent) {
         printf("%s%s ... OK %s[%s, %s:%d]\n", GREEN, expr, STOPCOLOR, func, filename, fileno);
-    } else {
+    } else if (!silent) {
         printf(".");
     }
 }
 
-PRIVATE void thc_add_failure(const char *expr, const char *func, const char *filename, const int fileno) {
-    if (verbose_tests) {
+PRIVATE void thc_add_failure(const char *expr, const char *func, const char *filename, const int fileno, const int silent) {
+    if (verbose_tests && !silent) {
         printf("%s%s ... FAIL %s[%s, %s:%d]\n", RED, expr, STOPCOLOR, func, filename, fileno);
-    } else {
+    } else if (!silent) {
         printf("F");
     }
     nfailures++;
@@ -64,11 +64,11 @@ PRIVATE void thc_report_tests(void) {
             time_elapsed, STOPCOLOR);
 }
 
-PUBLIC void thc_run_check(const int result, const char *expr, const char *func, const char *fname, const int fline) {
+PUBLIC void thc_run_check(const int result, const char *expr, const char *func, const char *fname, const int fline, const int silent) {
     if (result) {
-        thc_add_success(expr, func, fname, fline);
+        thc_add_success(expr, func, fname, fline, silent);
     } else {
-        thc_add_failure(expr, func, fname, fline);
+        thc_add_failure(expr, func, fname, fline, silent);
     }
 }
 

--- a/thc.h
+++ b/thc.h
@@ -1,7 +1,8 @@
 #ifndef _THC_INCLUDE
 #define _THC_INCLUDE
 
-#define ENSURE(expr) thc_run_check((expr), #expr, __func__, __FILE__, __LINE__)
+#define ENSURE(expr) thc_run_check((expr), #expr, __func__, __FILE__, __LINE__, 0)
+#define SILENT_ENSURE(expr) thc_run_check((expr), #expr, __func__, __FILE__, __LINE__, 1)
 
 enum {
     THC_QUIET = 0x1,    /* 0001 */
@@ -9,7 +10,7 @@ enum {
     THC_NOFORK = 0x4,   /* 0100 */
 };
 
-void thc_run_check(const int result, const char *expr, const char *func, const char *fname, const int fline);
+void thc_run_check(const int result, const char *expr, const char *func, const char *fname, const int fline, const int silent);
 void thc_addtest(void (*f)(void));
 int thc_run(int verbose);
 


### PR DESCRIPTION
I'm testing a generator like function, that yields char by char and I felt the need to SILENT_ENSURE (c == b) instead of ENSURE which prints #expr every time. I know thc has a non verbose mode but in this case I do want verbose output with specific silent ensures.
